### PR TITLE
feat: Add invalidate command

### DIFF
--- a/database.ts
+++ b/database.ts
@@ -80,7 +80,7 @@ export class SpellingDatabase {
     /**
      * Invalidate the spelling rules cache
      */
-    private invalidateCache(): void {
+    invalidateCache(): void {
         this.#rules = null;
     }
 }
@@ -147,7 +147,7 @@ export class CaseDatabase {
     /**
      * Invalidate the case rules cache
      */
-    private invalidateCache(): void {
+    invalidateCache(): void {
         this.#rules = null;
     }
 }

--- a/index.ts
+++ b/index.ts
@@ -2,9 +2,17 @@ import { Client, Events, GatewayIntentBits } from "discord.js";
 import { config } from "dotenv";
 import { Determiner } from "./determiner.ts";
 import { SpellingDatabase, CaseDatabase } from "./database.ts";
+import { REST, Routes, SlashCommandBuilder } from "discord.js";
 
 // 載入環境變數
 config();
+
+// 建立斜線指令
+const commands = [
+    new SlashCommandBuilder()
+        .setName("invalidate")
+        .setDescription("清除所有快取，從資料庫抓取資料。")
+];
 
 // 建立 client 實例
 const client = new Client({
@@ -25,8 +33,42 @@ const caseDatabase = await CaseDatabase.fromConnectionString(mongodbUri);
 const determiner = new Determiner(spellingDatabase, caseDatabase);
 
 // 當 bot 準備就緒時
-client.once(Events.ClientReady, async () => {
-    console.log(`Logged in as ${client.user?.tag}`);
+client.once(Events.ClientReady, async (c) => {
+    console.log(`Logged in as ${c.user.tag}`);
+
+    // 註冊斜線指令
+    const rest = new REST();
+    try {
+        console.log("開始註冊斜線指令");
+        await rest.put(
+            Routes.applicationCommands(c.user.id),
+            { body: commands },
+        );
+        console.log("成功註冊斜線指令");
+    } catch (error) {
+        console.error("註冊斜線指令時發生錯誤：", error);
+    }
+});
+
+// 處理斜線指令
+client.on(Events.InteractionCreate, async interaction => {
+    if (!interaction.isCommand()) return;
+
+    const { commandName } = interaction;
+
+    if (commandName === "invalidate") {
+        try {
+            spellingDatabase.invalidateCache();
+            caseDatabase.invalidateCache();
+            await interaction.reply({ content: "已清除所有快取！", ephemeral: true });
+        } catch (error) {
+            console.error("清除快取時發生錯誤：", error);
+            await interaction.reply({ 
+                content: "清除快取時發生錯誤，請稍後再試。", 
+                ephemeral: true 
+            });
+        }
+    }
 });
 
 /**
@@ -35,6 +77,7 @@ client.once(Events.ClientReady, async () => {
 client.on(Events.MessageCreate, async message => {
     // 忽略 bot 的訊息
     if (message.author.bot) return;
+
     try {
         const mistakes = await determiner.checkSpelling(message.content);
 

--- a/index.ts
+++ b/index.ts
@@ -80,8 +80,8 @@ client.on(Events.InteractionCreate, async interaction => {
             break;
 
         case "summary":
-            const spellingCount = await spellingDatabase.getRules();
-            const caseCount = await caseDatabase.getRules();
+            const spellingCount = (await spellingDatabase.getRules()).length;
+            const caseCount = (await caseDatabase.getRules()).length;
 
             await interaction.reply({ content: `目前有拼寫規則 ${spellingCount} 筆，大小寫規則 ${caseCount} 筆。`, ephemeral: true });
             break;

--- a/index.ts
+++ b/index.ts
@@ -39,8 +39,13 @@ const determiner = new Determiner(spellingDatabase, caseDatabase);
 client.once(Events.ClientReady, async (c) => {
     console.log(`Logged in as ${c.user.tag}`);
 
+    const discordToken = process.env.DISCORD_TOKEN;
+    if (!discordToken) {
+        throw new Error("DISCORD_TOKEN is not defined, so the bot cannot register slash commands.");
+    }
+
     // 註冊斜線指令
-    const rest = new REST();
+    const rest = new REST().setToken(discordToken);
     try {
         console.log("開始註冊斜線指令");
         await rest.put(

--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,10 @@ config();
 const commands = [
     new SlashCommandBuilder()
         .setName("invalidate")
-        .setDescription("清除所有快取，從資料庫抓取資料。")
+        .setDescription("清除所有快取，從資料庫抓取資料。"),
+    new SlashCommandBuilder()
+        .setName("summary")
+        .setDescription("查看目前資料筆數。"),
 ];
 
 // 建立 client 實例
@@ -56,18 +59,27 @@ client.on(Events.InteractionCreate, async interaction => {
 
     const { commandName } = interaction;
 
-    if (commandName === "invalidate") {
-        try {
-            spellingDatabase.invalidateCache();
-            caseDatabase.invalidateCache();
-            await interaction.reply({ content: "已清除所有快取！", ephemeral: true });
-        } catch (error) {
-            console.error("清除快取時發生錯誤：", error);
-            await interaction.reply({ 
-                content: "清除快取時發生錯誤，請稍後再試。", 
-                ephemeral: true 
-            });
-        }
+    switch (commandName) {
+        case "invalidate":
+            try {
+                spellingDatabase.invalidateCache();
+                caseDatabase.invalidateCache();
+                await interaction.reply({ content: "已清除所有快取！", ephemeral: true });
+            } catch (error) {
+                console.error("清除快取時發生錯誤：", error);
+                await interaction.reply({
+                    content: "清除快取時發生錯誤，請稍後再試。",
+                    ephemeral: true
+                });
+            }
+            break;
+
+        case "summary":
+            const spellingCount = await spellingDatabase.getRules();
+            const caseCount = await caseDatabase.getRules();
+
+            await interaction.reply({ content: `目前有拼寫規則 ${spellingCount} 筆，大小寫規則 ${caseCount} 筆。`, ephemeral: true });
+            break;
     }
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new slash command “invalidate” for the Discord bot, enabling users to clear cached data on demand with immediate feedback.
	- Added a new slash command “summary” to retrieve the current count of data entries.
	- Enhanced cache management to ensure smoother interactions and improved performance when utilizing these commands.
- **Bug Fixes**
	- Improved error handling during the registration of slash commands to log any issues that arise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->